### PR TITLE
Add support for PROXY protocol command

### DIFF
--- a/mailific-serverlib/src/main/java/net/mailific/server/commands/Proxy.java
+++ b/mailific-serverlib/src/main/java/net/mailific/server/commands/Proxy.java
@@ -1,3 +1,21 @@
+/*-
+ * Mailific SMTP Server Library
+ *
+ * Copyright (C) 2021-2022 Joe Humphreys
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.mailific.server.commands;
 
 import net.mailific.server.session.*;

--- a/mailific-serverlib/src/main/java/net/mailific/server/commands/Proxy.java
+++ b/mailific-serverlib/src/main/java/net/mailific/server/commands/Proxy.java
@@ -1,0 +1,40 @@
+package net.mailific.server.commands;
+
+import net.mailific.server.session.*;
+
+/**
+ * Implements the PROXY protocol https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+ * used by HAProxy and nginx to pass client connection information.
+ * nginx supports the PROXY protocol when it proxies a mail server, but to do things like
+ * SPF, we need to know the original client IP address.
+ *
+ * This command collects the client IP address from the PROXY command and stores it in
+ * the SESSION_CLIENTIP_PROPERTY property of the session.
+ * (Perhaps at some point we should add the ability to change the remote address of the
+ * SmtpSession.)
+ */
+public class Proxy extends BaseHandler {
+    public static final String SESSION_CLIENTIP_PROPERTY = "proxied-client.ip";
+
+    @Override
+    protected Transition handleValidCommand(SmtpSession session, String commandLine) {
+        var parts = commandLine.split(" ");
+        // line is of the form (TCP6 is also supported):
+        // PROXY TCP4 src_ip dst_ip src_port dst_port
+        if (parts.length == 6) {
+            var clientIp = parts[2];
+            session.setProperty(SESSION_CLIENTIP_PROPERTY, clientIp);
+        }
+        return new Transition(Reply.DO_NOT_REPLY, SessionState.NO_STATE_CHANGE);
+    }
+
+    @Override
+    protected boolean validForState(SessionState state) {
+        return state == StandardStates.CONNECTED;
+    }
+
+    @Override
+    public String verb() {
+        return "PROXY";
+    }
+}

--- a/mailific-serverlib/src/test/java/net/mailific/server/commands/ProxyTest.java
+++ b/mailific-serverlib/src/test/java/net/mailific/server/commands/ProxyTest.java
@@ -1,0 +1,88 @@
+/*-
+ * Mailific SMTP Server Library
+ *
+ * Copyright (C) 2021-2022 Joe Humphreys
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.mailific.server.commands;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+
+import java.util.EnumSet;
+import net.mailific.server.extension.auth.TransitionMatcher;
+import net.mailific.server.session.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ProxyTest {
+
+    @Mock SmtpSession session;
+
+    Proxy it;
+
+    private AutoCloseable closeable;
+
+    @Before
+    public void setUp() {
+        closeable = MockitoAnnotations.openMocks(this);
+
+        it = new Proxy();
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    public void happyPath() {
+        Transition t = it.handleValidCommand(session, "PROXY TCP6 5::ffff d::ffff 5555 2222");
+
+        verify(session).setProperty(Proxy.SESSION_CLIENTIP_PROPERTY, "5::ffff");
+        assertThat(t, TransitionMatcher.with(Reply.DO_NOT_REPLY, SessionState.NO_STATE_CHANGE));
+    }
+
+    @Test
+    public void badParams() {
+        Transition t = it.handleValidCommand(session, "PROXY TCP6 5::ffff d::ffff 5555");
+        assertThat(t, TransitionMatcher.with(Reply.DO_NOT_REPLY, SessionState.NO_STATE_CHANGE));
+    }
+
+    @Test
+    public void validForState() {
+        for (StandardStates state : EnumSet.allOf(StandardStates.class)) {
+            switch (state) {
+                case CONNECTED:
+                    assertTrue(it.validForState(state));
+                    break;
+                default:
+                    assertFalse(it.validForState(state));
+            }
+        }
+    }
+
+    @Test
+    public void command() {
+        assertEquals("PROXY", it.verb());
+    }
+}


### PR DESCRIPTION
Implements the PROXY protocol
https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt used by HAProxy and nginx to pass client connection information. nginx supports the PROXY protocol when it proxies a mail server, but to do things like SPF, we need to know the original client IP address.